### PR TITLE
Adding an explicit LICENSE.txt file to make compliance people happy.

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,10 @@
+Copyright 2011 Google Inc.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+     http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.


### PR DESCRIPTION
**Problem:**
* JFROG Artifactory's X-Ray license scanning feature doesn't see the licensing, which makes compliance people talk to engineers.

**Solution:**
* Adding an explicit LICENSE.txt file from the LICENSE comment in the code.  
* This will help JFROG Artifactory's x-ray scanner pick up the license so compliance people around the world are happy.

Happy Hacking!

Sam